### PR TITLE
Finalize go key split

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,0 +1,1 @@
+1.0.0: QmT9tw9haE1UjSYu51uUxQ8bEqefMdRLKJQcryBEAM7Zuq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+os:
+  - linux
+  - osx
+
+language: go
+
+go:
+    - 1.5.2
+
+env:
+    - GO15VENDOREXPERIMENT=1
+
+install: true
+
+script:
+  - make deps
+  - go test ./...
+
+cache:
+    directories:
+        - $GOPATH/src/gx
+
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Juan Batiz-Benet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Juan Batiz-Benet
+Copyright (c) 2016 Protocol Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+export IPFS_API ?= v04x.ipfs.io
+
+gx:
+	go get -u github.com/whyrusleeping/gx
+	go get -u github.com/whyrusleeping/gx-go
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# go-key
+A string representation of [multihash](https://github.com/multiformats/go-multihash) for use with maps.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # go-key
-A string representation of [multihash](https://github.com/multiformats/go-multihash) for use with maps.
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> string representation of [multihash](https://github.com/multiformats/go-multihash) for use with maps
+
+## Documenation
+
+See https://godoc.org/github.com/ipfs/go-key.
+
+## Contribute
+
+Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/go-key/issues)!
+
+This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+### Want to hack on IPFS?
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+
+## License
+
+MIT

--- a/key.go
+++ b/key.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	b58 "gx/ipfs/QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf/go-base58"
-	ds "gx/ipfs/QmTxLSvdhwg68WJimdS6icLPhZi28aTp6b7uihC2Yb47Xk/go-datastore"
-	mh "gx/ipfs/QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku/go-multihash"
-	base32 "gx/ipfs/Qmb1DA2A9LS2wR4FFweB4uEDomFsdmnw1VLawLE1yQzudj/base32"
+	ds "github.com/ipfs/go-datastore"
+	b58 "github.com/jbenet/go-base58"
+	mh "github.com/jbenet/go-multihash"
+	base32 "github.com/whyrusleeping/base32"
 )
 
 // Key is a string representation of multihash for use with maps.

--- a/key_test.go
+++ b/key_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	mh "gx/ipfs/QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku/go-multihash"
+	mh "github.com/jbenet/go-multihash"
 )
 
 func TestKey(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-key",
-  "version": "0.0.0"
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "bugs": {
+    "url": "https://github.com/ipfs/go-key"
+  },
+  "gx": {
+    "dvcsimport": "github.com/ipfs/go-key",
+    "goversion": "1.5.2"
+  },
+  "gxDependencies": [
+    {
+      "author": "jbenet",
+      "hash": "QmTxLSvdhwg68WJimdS6icLPhZi28aTp6b7uihC2Yb47Xk",
+      "name": "go-datastore",
+      "version": "0.2.0"
+    },
+    {
+      "hash": "QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku",
+      "name": "go-multihash",
+      "version": "0.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "Qmb1DA2A9LS2wR4FFweB4uEDomFsdmnw1VLawLE1yQzudj",
+      "name": "base32",
+      "version": "0.0.0"
+    },
+    {
+      "author": "jbenet",
+      "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
+      "name": "base58",
+      "version": "0.0.0"
+    }
+  ],
+  "gxVersion": "0.4.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "go-key",
+  "version": "0.0.0"
+}


### PR DESCRIPTION
This should wrap up the split of `go-key` from `go-ipfs`.

* Undoes gx rewrite
* Adds travis-ci
* Adds `README` and `LICENCE`
* Publishes `1.0.0` to gx

@whyrusleeping if can please enable travis for this repo first so we can see that everything works as expected.