### PR TITLE
Bump 'go-datastore' to '1.0.0'

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.1: QmXhU58jbgCbuAvo3Eq6VXg67yGSNArpzJwk3g54NuYVfx
+1.0.2: Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ os:
 language: go
 
 go:
-    - 1.5.2
-
-env:
-    - GO15VENDOREXPERIMENT=1
+    - 1.7
 
 install: true
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "jbenet",
-      "hash": "QmTxLSvdhwg68WJimdS6icLPhZi28aTp6b7uihC2Yb47Xk",
+      "hash": "QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU",
       "name": "go-datastore",
-      "version": "0.2.0"
+      "version": "1.0.0"
     },
     {
       "hash": "QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku",
@@ -35,5 +35,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-key",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
```
gx deps -r -s
base32       Qmb1DA2A9LS2wR4FFweB4uEDomFsdmnw1VLawLE1yQzudj 0.0.0
go-base58    QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf 0.0.0
go-crypto    Qme1boxspcQWR8FBzMxeppqug2fYgYc15diNWmqgDVnvn2 0.0.0
go-datastore QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU 1.0.0
go-multihash QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku 0.0.0
go.uuid      QmcyaFHbyiZfoX5GTpcqqCPYmbjYNAhRDekXSJPFHdYNSV 1.0.0
goprocess    QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP 1.0.0
```

Also moved to go 1.7